### PR TITLE
Implement ephemeral welcome channels

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,7 @@
 import os
 import discord
 import asyncio
+from discord.ext import commands
 
 TOKEN = os.getenv('DISCORD_TOKEN')
 
@@ -8,7 +9,7 @@ intents = discord.Intents.default()
 intents.guilds = True
 intents.members = True
 
-bot = discord.Client(intents=intents)
+bot = commands.Bot(command_prefix="!", intents=intents)
 
 OPENING_MESSAGES = [
     "마을의 낯선 이여, 이곳에 처음 오셨군요. 반갑습니다! 🌟",
@@ -17,15 +18,37 @@ OPENING_MESSAGES = [
     "아래 안내에 따라 #직업선택 채널로 이동해 주세요."
 ]
 
+
+async def delete_channel_later(channel: discord.TextChannel, delay: int = 60):
+    await asyncio.sleep(delay)
+    await channel.delete()
+
+
 @bot.event
 async def on_member_join(member):
     guild = member.guild
-    channel = discord.utils.get(guild.text_channels, name="마을광장")
-    if channel is None:
-        return
+    hash_suffix = hex(member.id)[-4:]
+    overwrites = {
+        guild.default_role: discord.PermissionOverwrite(read_messages=False),
+        member: discord.PermissionOverwrite(read_messages=True),
+    }
+    channel = await guild.create_text_channel(
+        name=f"welcome-{hash_suffix}", overwrites=overwrites
+    )
     for msg in OPENING_MESSAGES:
         await channel.send(msg)
         await asyncio.sleep(5)
+    asyncio.create_task(delete_channel_later(channel))
+
+
+@bot.command(name="choose")
+async def choose(ctx, *, job: str):
+    guild = ctx.guild
+    role = discord.utils.get(guild.roles, name=job)
+    if role is None:
+        role = await guild.create_role(name=job)
+    await ctx.author.add_roles(role)
+    await ctx.send(f"{ctx.author.mention}님, {job} 직업이 선택되었습니다!")
 
 if __name__ == "__main__":
     bot.run(TOKEN)


### PR DESCRIPTION
## Summary
- add ephemeral welcome channel with hashed names for each new member
- convert bot to `commands.Bot` and add `!choose` command to assign job roles

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6851f2c4d5008324a3dd49d756c4787c