### PR TITLE
Implement newcomer role and update NPC name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ It guides new users through the introductory channel `#마을광장` and leads t
 
 3. Run the bot: `python bot.py`
 
-When a new member joins, the bot creates a private temporary channel where only
-the newcomer can see the introductory messages. This channel is automatically
-deleted shortly after the conversation ends.
+When a new member joins, the bot assigns them a temporary role called `신입`
+and creates a private channel only they can see. After they choose one of the
+job roles (`전사`, `마법사`, or `암살자`), the temporary role is removed and the
+channel is deleted shortly after the conversation ends. The NPC guiding them is
+named **이름모를불꽃**.
 
 This script showcases the conversation flow described in the previous scenario.

--- a/bot.py
+++ b/bot.py
@@ -16,12 +16,14 @@ intents = discord.Intents.default()
 intents.guilds = True
 intents.members = True
 
+NEWCOMER_ROLE_NAME = "신입"
+JOB_ROLES = ["전사", "마법사", "암살자"]
 bot = commands.Bot(command_prefix="!", intents=intents)
 
 OPENING_MESSAGES = [
     "마을의 낯선 이여, 이곳에 처음 오셨군요. 반갑습니다! 🌟",
     "조금만 기다리시면 저희 마을의 간단한 안내를 드리겠습니다.",
-    "저는 이 마을을 지키는 안내자, NPC 알베르트입니다.",
+    "저는 이 마을을 지키는 안내자, NPC 이름모를불꽃입니다.",
     "아래 안내에 따라 #직업선택 채널로 이동해 주세요."
 ]
 
@@ -34,6 +36,10 @@ async def delete_channel_later(channel: discord.TextChannel, delay: int = 60):
 @bot.event
 async def on_member_join(member):
     guild = member.guild
+    newbie_role = discord.utils.get(guild.roles, name=NEWCOMER_ROLE_NAME)
+    if newbie_role is None:
+        newbie_role = await guild.create_role(name=NEWCOMER_ROLE_NAME)
+    await member.add_roles(newbie_role)
     hash_suffix = hex(member.id)[-4:]
     overwrites = {
         guild.default_role: discord.PermissionOverwrite(read_messages=False),
@@ -50,11 +56,17 @@ async def on_member_join(member):
 
 @bot.command(name="choose")
 async def choose(ctx, *, job: str):
+    if job not in JOB_ROLES:
+        await ctx.send("존재하지 않는 직업입니다.")
+        return
     guild = ctx.guild
     role = discord.utils.get(guild.roles, name=job)
     if role is None:
         role = await guild.create_role(name=job)
     await ctx.author.add_roles(role)
+    newbie_role = discord.utils.get(guild.roles, name=NEWCOMER_ROLE_NAME)
+    if newbie_role and newbie_role in ctx.author.roles:
+        await ctx.author.remove_roles(newbie_role)
     await ctx.send(f"{ctx.author.mention}님, {job} 직업이 선택되었습니다!")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rename NPC to `이름모를불꽃`
- add `신입` newcomer role logic so members can access channels only after picking a job
- validate job choice against warrior, mage, assassin
- remove newcomer role once a job is picked
- document the new behaviour in `README.md`

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68526a5344b88324abdd5be0c5bd0458