### PR TITLE
Fix message content intent

### DIFF
--- a/invite_role_bot.py
+++ b/invite_role_bot.py
@@ -12,6 +12,7 @@ DISCORD_TOKEN = config["token"]
 
 intents = discord.Intents.default()
 intents.members = True
+intents.message_content = True
 bot = commands.Bot(command_prefix="!", intents=intents)
 
 # Messages sent to new members when they join the server. Adjust the content as


### PR DESCRIPTION
## Summary
- set `intents.message_content = True` so command prefix messages work

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852790cbbf4832486f8a4fcf89162e7