### PR TITLE
Fix Missing Access error for welcome channel

### DIFF
--- a/invite_role_bot.py
+++ b/invite_role_bot.py
@@ -42,6 +42,9 @@ async def on_member_join(member: discord.Member):
     overwrites = {
         guild.default_role: discord.PermissionOverwrite(read_messages=False),
         member: discord.PermissionOverwrite(read_messages=True),
+        guild.me: discord.PermissionOverwrite(
+            read_messages=True, send_messages=True
+        ),
     }
 
     channel = await guild.create_text_channel(


### PR DESCRIPTION
## Summary
- ensure the bot can read and send messages in welcome channels

## Testing
- `python -m py_compile invite_role_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68527a02850c8324aa3069c3f17564bd