### PR TITLE
Implement channel and role cleanup

### DIFF
--- a/invite_role_bot.py
+++ b/invite_role_bot.py
@@ -23,11 +23,65 @@ OPENING_MESSAGES = [
     "즐거운 시간 되세요!"
 ]
 
+# Mapping from emoji to job role names used for reaction role assignment.
+ROLE_EMOJIS = {
+    "⚔️": "전사",
+    "🧙": "마법사",
+    "🥷": "암살자",
+}
 
-async def delete_channel_later(channel: discord.TextChannel, delay: int = 300):
-    """Delete the given channel after a delay in seconds."""
+
+async def delete_channel_later(
+    channel: discord.TextChannel,
+    role: discord.Role | None = None,
+    delay: int = 300,
+) -> None:
+    """Delete the given channel (and role) after a delay in seconds."""
     await asyncio.sleep(delay)
+    if role is not None:
+        # Delete the role if it still exists. Removing the role will also
+        # automatically unassign it from any members.
+        guild_role = channel.guild.get_role(role.id)
+        if guild_role is not None:
+            await guild_role.delete(reason="welcome channel cleanup")
+
     await channel.delete(reason="welcome channel cleanup")
+
+
+async def ask_for_job(
+    channel: discord.TextChannel,
+    member: discord.Member,
+    private_role: discord.Role,
+) -> None:
+    """Ask the member to choose a job via reactions and grant the role."""
+    description = "\n".join(f"{emoji} : {name}" for emoji, name in ROLE_EMOJIS.items())
+    prompt = await channel.send(
+        "원하는 직업의 이모지를 눌러 주세요:\n" + description
+    )
+
+    for emoji in ROLE_EMOJIS.keys():
+        await prompt.add_reaction(emoji)
+
+    def check(reaction: discord.Reaction, user: discord.User) -> bool:
+        return (
+            reaction.message.id == prompt.id
+            and user.id == member.id
+            and str(reaction.emoji) in ROLE_EMOJIS
+        )
+
+    try:
+        reaction, _ = await bot.wait_for("reaction_add", check=check, timeout=60)
+    except asyncio.TimeoutError:
+        await channel.send("시간이 초과되어 채널을 정리합니다.")
+    else:
+        role_name = ROLE_EMOJIS[str(reaction.emoji)]
+        role = discord.utils.get(channel.guild.roles, name=role_name)
+        if role is None:
+            role = await channel.guild.create_role(name=role_name)
+        await member.add_roles(role)
+        await channel.send(f"{member.mention}님께 {role.name} 역할을 부여했어요!")
+
+    asyncio.create_task(delete_channel_later(channel, private_role, delay=60))
 
 
 @bot.event
@@ -35,9 +89,12 @@ async def on_ready():
     print(f"Logged in as {bot.user.name}")
 
 
-async def create_invite_channel(guild: discord.Guild, member: discord.Member) -> discord.TextChannel:
+async def create_invite_channel(
+    guild: discord.Guild, member: discord.Member
+) -> tuple[discord.TextChannel, discord.Role]:
     """Create a private role and channel for the given member."""
-    role_name = f"\ud83d\udd12\uc784\uc2dc\uc695\uc815-{member.id}"
+
+    role_name = f"🔒임시역할-{member.id}"
     role = discord.utils.get(guild.roles, name=role_name)
     if role is None:
         role = await guild.create_role(name=role_name)
@@ -51,33 +108,34 @@ async def create_invite_channel(guild: discord.Guild, member: discord.Member) ->
     }
 
     channel = await guild.create_text_channel(
-        name=f"\ube44\uacf5\uac1c-{member.id}",
+        name=f"비공개-{member.id}",
         overwrites=overwrites,
-        reason="\uc2e0\uad8c \uc0ac\uc6a9\uc790 \uc804\uc6a9 \ucc44\ub110",
+        reason="신규 사용자 전용 채널",
     )
-    return channel
+    return channel, role
 
 
 @bot.event
 async def on_member_join(member: discord.Member):
     guild = member.guild
-    channel = await create_invite_channel(guild, member)
+    channel, private_role = await create_invite_channel(guild, member)
 
     for msg in OPENING_MESSAGES:
         await channel.send(msg)
         await asyncio.sleep(5)
 
-    asyncio.create_task(delete_channel_later(channel))
+    await ask_for_job(channel, member, private_role)
 
 
 @bot.command(name="초대")
 async def invite_channel(ctx, member: discord.Member):
     guild = ctx.guild
-    channel = await create_invite_channel(guild, member)
+    channel, private_role = await create_invite_channel(guild, member)
     await ctx.send(
         f"\ud83c\udf39 {member.mention}\ub2d8\uc744 \uc704\ud55c \ucc44\ub110 {channel.mention}\uc774 \uc0dd\uc131\ub418\uc5c8\uc5b4\uc694."
     )
 
+    await ask_for_job(channel, member, private_role)
 
 if __name__ == "__main__":
     bot.run(DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- delete temporary role when cleaning up channel
- pass private role to `ask_for_job`
- return role from `create_invite_channel`
- clean up channel name and role name

## Testing
- `python -m py_compile invite_role_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68527e3398f48324ab414f2eff6acb1e