### PR TITLE
Shorten temp cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,7 @@ It guides new users through the introductory channel `#마을광장`, encourages
 Use the `초대` command to invite a member. The bot grants a temporary role and
 creates a private channel they can access. The channel is automatically
 generated for short-term conversations and can be removed afterwards.
+The cleanup now happens just 10 seconds after the user picks a role or the
+selection times out.
 
 This script showcases the conversation flow described in the previous scenario.

--- a/invite_role_bot.py
+++ b/invite_role_bot.py
@@ -34,7 +34,7 @@ ROLE_EMOJIS = {
 async def delete_channel_later(
     channel: discord.TextChannel,
     role: discord.Role | None = None,
-    delay: int = 300,
+    delay: int = 10,
 ) -> None:
     """Delete the given channel (and role) after a delay in seconds."""
     await asyncio.sleep(delay)
@@ -81,7 +81,8 @@ async def ask_for_job(
         await member.add_roles(role)
         await channel.send(f"{member.mention}님께 {role.name} 역할을 부여했어요!")
 
-    asyncio.create_task(delete_channel_later(channel, private_role, delay=60))
+    # Clean up the temporary channel and role shortly after use.
+    asyncio.create_task(delete_channel_later(channel, private_role, delay=10))
 
 
 @bot.event


### PR DESCRIPTION
## Summary
- decrease `delete_channel_later` default delay to 10 seconds
- trigger cleanup after 10 seconds once the job is selected
- document new delay in README

## Testing
- `python -m py_compile invite_role_bot.py`
- `python invite_role_bot.py --help` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68527fbb49708324b7d3912d2377e5f2