### PR TITLE
Extend reaction timeout to 10 min

### DIFF
--- a/invite_role_bot.py
+++ b/invite_role_bot.py
@@ -70,7 +70,8 @@ async def ask_for_job(
         )
 
     try:
-        reaction, _ = await bot.wait_for("reaction_add", check=check, timeout=60)
+        # Give users up to 10 minutes to pick their role before timing out.
+        reaction, _ = await bot.wait_for("reaction_add", check=check, timeout=600)
     except asyncio.TimeoutError:
         await channel.send("시간이 초과되어 채널을 정리합니다.")
     else:


### PR DESCRIPTION
## Summary
- give users up to 10 minutes to pick their role

## Testing
- `python -m py_compile invite_role_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68528558836083248ea7b62eeebce3ad